### PR TITLE
Workflow fix

### DIFF
--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: Launcher-MacOS
-          path: artifacts/mac
+          path: artifacts
       - name: Upload artifacts (win)
         if: matrix.os == 'windows-latest'
         uses: actions/upload-artifact@v1


### PR DESCRIPTION
This PR makes a change to the electron/launcher build workflow to fix the error about a non-existent artifact path.